### PR TITLE
Fix hash sign hexcode in DigiKeyboardDe.h

### DIFF
--- a/digistump-avr/libraries/DigisparkKeyboard/DigiKeyboardDe.h
+++ b/digistump-avr/libraries/DigisparkKeyboard/DigiKeyboardDe.h
@@ -49,7 +49,7 @@ const uint16_t _ascii_de_map[128] PROGMEM =
                 0x2c,      //  ' '
                 0x1e|DE_MOD_SHIFT_LEFT,    // !
                 0x1F|DE_MOD_SHIFT_LEFT,    // "
-                0x38,    // #
+                0x32,    // #
                 0x21|DE_MOD_SHIFT_LEFT,    // $
                 0x22|DE_MOD_SHIFT_LEFT,    // %
                 0x23|DE_MOD_SHIFT_LEFT,    // &


### PR DESCRIPTION
Trying to type a `#` character currently results in a `-` character being written. Fixed by setting the correct hex code `0x32`.